### PR TITLE
Updated homepage & url in formula for popt

### DIFF
--- a/Library/Formula/popt.rb
+++ b/Library/Formula/popt.rb
@@ -6,6 +6,7 @@ class Popt < Formula
 
   option :universal
 
+  
   def install
     ENV.universal_binary if build.universal?
     system "./configure", "--disable-debug", "--disable-dependency-tracking",


### PR DESCRIPTION
I changed the homepage to "https://github.com/rpm-software-management/popt" and the download url to "https://github.com/rpm-software-management/popt/archive/popt-1_16-release.tar.gz" as recommended by @jupo42 in pull request mistydemeo#667.

Also I removed the bottles for the newer MacOS versions and adjusted the sha256 hash.